### PR TITLE
Composition

### DIFF
--- a/src/composition.rs
+++ b/src/composition.rs
@@ -1,0 +1,65 @@
+/// Allows for converting from a child error type to a parent
+/// error type while preserving any context on the child error.
+///
+/// This is intended to be used when:
+///   1. Both Source and Target are context enriched thiserror enums
+///   2. Source is a variant of Target's inner error
+///
+/// ** Example **
+/// ```ignore
+/// // Some inner error type
+/// #[derive(Debug, Error)]
+/// pub enum InnerError {
+///     #[error("dummy")]
+///     Dummy,
+/// }
+/// impl_context(Inner(InnerError));
+///
+/// // And some outer error type, which contains
+/// // a variant of the inner error type
+/// #[derive(Debug, Error)]
+/// pub enum OuterError {
+///     #[error("inner error")]
+///     // we explicitly do _not_ use #[from] here, instead
+///     // opting to use the macro to create the conversion
+///     // and handle the context propagation.
+///     Inner(InnerError),
+/// }
+/// impl_context(Outer(OuterError));
+///
+/// // Then we use the macro to implement the conversion
+/// // from Inner to Outer
+/// impl_from_carry_context!(Inner, Outer, OuterError::Inner);
+/// ```
+#[macro_export]
+macro_rules! impl_from_carry_context {
+    ($source: ident, $target: ident, $variant: path) => {
+        impl From<$source> for $target {
+            fn from(mut value: $source) -> Self {
+                let mut contexts = vec![];
+
+                let inner = loop {
+                    match value {
+                        $source::Base(x) => break x,
+                        $source::Context { context, error } => {
+                            contexts.push(context);
+                            value = *error;
+                        }
+                    }
+                };
+                let inner = $source::Base(inner);
+
+                let mut x = $target::Base($variant(inner));
+
+                for ctx in contexts.into_iter().rev() {
+                    x = $target::Context {
+                        context: ctx,
+                        error: Box::new(x),
+                    };
+                }
+
+                x
+            }
+        }
+    };
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,8 @@
 //!
 //! [thiserror]: https://docs.rs/thiserror
 //! [anyhow]: https://docs.rs/anyhow
+mod composition;
+
 use std::fmt::Display;
 
 /// Defines a new struct that wraps the error type, allowing additional
@@ -106,7 +108,11 @@ macro_rules! impl_context {
         impl std::fmt::Debug for $out {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), core::fmt::Error> {
                 let (context, root) = self.all(vec![]);
-                f.write_fmt(format_args!("{:?}\n\nCaused by:\n", root))?;
+                f.write_fmt(format_args!("{:?}", root))?; //Caused by:\n", root))?;
+
+                if !context.is_empty() {
+                    f.write_fmt(format_args!("\n\nCaused by:\n"))?;
+                }
 
                 for (i, context) in context.iter().enumerate() {
                     f.write_fmt(format_args!("    {i}: {}\n", context))?;
@@ -201,12 +207,6 @@ mod tests {
         ParseInt(#[from] std::num::ParseIntError),
     }
 
-    #[derive(Debug, Error)]
-    pub enum Other {
-        #[error("t {0}")]
-        T(#[from] DummyError),
-    }
-
     impl_context!(DummyError(DummyErrorInner));
 
     fn t() -> Result<(), DummyError> {
@@ -216,18 +216,16 @@ mod tests {
 
     #[test]
     fn it_works() {
-        let r: Result<(), DummyErrorInner> = Err(DummyErrorInner::Dummy);
-
-        let r = r
+        let r = t()
             .context("first")
-            .with_context(|| format!("second dynamic"))
-            .context("third");
+            .with_context::<String, _>(|| format!("second dynamic"))
+            .context("third"); //: Result<(), DummyError> = Err(DummyErrorInner::Dummy.into());
 
-        let r = format!("{:#?}", r.unwrap_err());
+        let res = format!("{:#?}", r.as_ref().unwrap_err());
 
         assert_eq!(
-            r,
-            "dummy err msg\n\nCaused by:\n    0: third\n    1: second dynamic\n    2: first\n"
+            res,
+            "ParseInt(ParseIntError { kind: InvalidDigit })\n\nCaused by:\n    0: third\n    1: second dynamic\n    2: first\n"
         );
     }
 
@@ -239,7 +237,99 @@ mod tests {
 
         assert_eq!(
             r,
-            "parse int err: invalid digit found in string\n\nCaused by:\n    0: second\n    1: parsing test\n",
+            "ParseInt(ParseIntError { kind: InvalidDigit })\n\nCaused by:\n    0: second\n    1: parsing test\n",
+        );
+    }
+
+    #[test]
+    fn no_contrext_omits_causation() {
+        let r = t();
+
+        let r = format!("{:#?}", r.unwrap_err());
+
+        assert_eq!(r, "ParseInt(ParseIntError { kind: InvalidDigit })",);
+    }
+}
+
+#[cfg(test)]
+mod composable_tests {
+    use super::*;
+    use inner::DummyError;
+    use thiserror::Error;
+
+    mod inner {
+        use crate::Context;
+        use thiserror::Error;
+
+        #[derive(Debug, Error)]
+        pub enum DummyErrorInner {
+            #[error("dummy err msg")]
+            Dummy,
+            #[error("parse int err: {0}")]
+            ParseInt(#[from] std::num::ParseIntError),
+        }
+        impl_context!(DummyError(DummyErrorInner));
+
+        pub fn t() -> Result<(), DummyError> {
+            Err::<(), DummyErrorInner>(DummyErrorInner::Dummy.into())
+                .context("first")
+                .context("second")
+        }
+    }
+
+    #[derive(Debug, Error)]
+    pub enum OtherInner {
+        #[error("t {0}")]
+        T(DummyError),
+    }
+
+    impl From<DummyError> for Other {
+        fn from(mut value: DummyError) -> Self {
+            let mut contexts = vec![];
+
+            let inner = loop {
+                match value {
+                    DummyError::Base(x) => break x,
+                    DummyError::Context { context, error } => {
+                        contexts.push(context);
+                        value = *error;
+                    }
+                }
+            };
+            let inner = DummyError::Base(inner);
+
+            let mut x = Other::Base(OtherInner::T(inner));
+
+            for ctx in contexts.into_iter().rev() {
+                x = Other::Context {
+                    context: ctx,
+                    error: Box::new(x),
+                };
+            }
+
+            x
+        }
+    }
+
+    impl_context!(Other(OtherInner));
+
+    fn wrapped() -> Result<(), Other> {
+        _wrapped().context("fourth")
+    }
+
+    fn _wrapped() -> Result<(), Other> {
+        inner::t().context("third")
+    }
+
+    #[test]
+    fn it_is_composable() {
+        let r = wrapped();
+
+        let r = format!("{:#?}", r.unwrap_err());
+
+        assert_eq!(
+            r,
+            "T(Dummy)\n\nCaused by:\n    0: fourth\n    1: third\n    2: second\n    3: first\n",
         );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -283,33 +283,7 @@ mod composable_tests {
         T(DummyError),
     }
 
-    impl From<DummyError> for Other {
-        fn from(mut value: DummyError) -> Self {
-            let mut contexts = vec![];
-
-            let inner = loop {
-                match value {
-                    DummyError::Base(x) => break x,
-                    DummyError::Context { context, error } => {
-                        contexts.push(context);
-                        value = *error;
-                    }
-                }
-            };
-            let inner = DummyError::Base(inner);
-
-            let mut x = Other::Base(OtherInner::T(inner));
-
-            for ctx in contexts.into_iter().rev() {
-                x = Other::Context {
-                    context: ctx,
-                    error: Box::new(x),
-                };
-            }
-
-            x
-        }
-    }
+    impl_from_carry_context!(DummyError, Other, OtherInner::T);
 
     impl_context!(Other(OtherInner));
 


### PR DESCRIPTION
This PR adds the ability to compose contextualized Error enums. The allows users to convert from a child error to a parent, while preserving any context on the child item.