### PR TITLE
Name conflict if `Result` exists

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -300,7 +300,7 @@ macro_rules! impl_context {
         }
 
         impl std::fmt::Debug for $out {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), core::fmt::Error> {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let (context, root) = self.all(vec![]);
                 f.write_fmt(format_args!("{:?}", root))?; //Caused by:\n", root))?;
 
@@ -334,8 +334,8 @@ macro_rules! impl_context {
             }
         }
 
-        impl<Z, E: Into<$out>> Context<$out, Z, E> for Result<Z, E> {
-            fn context<C>(self, context: C) -> Result<Z, $out>
+        impl<Z, E: Into<$out>> Context<$out, Z, E> for core::result::Result<Z, E> {
+            fn context<C>(self, context: C) -> core::result::Result<Z, $out>
             where
                 C: std::fmt::Display + Send + Sync + 'static,
             {
@@ -351,7 +351,7 @@ macro_rules! impl_context {
                 }
             }
 
-            fn with_context<C, F>(self, f: F) -> Result<Z, $out>
+            fn with_context<C, F>(self, f: F) -> core::result::Result<Z, $out>
             where
                 C: std::fmt::Display + Send + Sync + 'static,
                 F: FnOnce() -> C,
@@ -376,13 +376,13 @@ where
     E: Into<W>,
 {
     /// Wrap the error value with additional context.
-    fn context<C>(self, context: C) -> Result<T, W>
+    fn context<C>(self, context: C) -> core::result::Result<T, W>
     where
         C: Display + Send + Sync + 'static;
 
     /// Wrap the error value with additional context that is evaluated lazily
     /// only once an error does occur.
-    fn with_context<C, F>(self, f: F) -> Result<T, W>
+    fn with_context<C, F>(self, f: F) -> core::result::Result<T, W>
     where
         C: Display + Send + Sync + 'static,
         F: FnOnce() -> C;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -522,4 +522,22 @@ mod composable_tests {
             "T(Dummy)\n\nCaused by:\n    0: fourth\n    1: third\n    2: second\n    3: first\n",
         );
     }
+
+    #[test]
+    fn result_is_not_conflict() {
+        use crate::Context;
+
+        #[derive(Debug, thiserror::Error)]
+        pub enum DummyErrorInner {
+            #[error("dummy err msg")]
+            Dummy,
+        }
+
+        impl_context!(DummyError(DummyErrorInner));
+
+        #[allow(dead_code)]
+        type Result = core::result::Result<(), DummyError>;
+
+        // note: no actual code to succeed -- compilation is success
+    }
 }


### PR DESCRIPTION
Dear Maintainer,

if there is a type called `Result` in the same scope as the macro invocation to `impl_context!`, the compilation fails as of now (with a rather cryptic error):

```
90 | impl_context!(ErrorWithContext(SimpleErr));
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `std::fmt::Error`, found `error::Error`
   |
   = note: expected signature `fn(&ErrorWithContext, &mut Formatter<'_>) -> std::result::Result<_, std::fmt::Error>`
              found signature `fn(&ErrorWithContext, &mut Formatter<'_>) -> std::result::Result<_, error::Error>`
   = note: this error originates in the macro `impl_context` (in Nightly builds, run with -Z macro-backtrace for more info)
help: change the output type to match the trait
  --> /home/s9105947/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/thiserror-context-0.1.2/src/lib.rs:303:63
   |
303-             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), core::fmt::Error> {
303+             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
   |

error[E0277]: `?` couldn't convert the error to `error::Error`
  --> src/error.rs:90:1
   |
90 | impl_context!(ErrorWithContext(SimpleErr));
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   | |
   | this can't be annotated with `?` because it has type `Result<_, std::fmt::Error>`
   | the trait `From<std::fmt::Error>` is not implemented for `error::Error`
```

This PR (1) adds a test case for this, and (2) fixes it by referring to `core::result::Result` instead of only `Result`.

This is my first time working with macros, and I just followed my gut with the fix. It works, but if it goes against best practices please let me know.